### PR TITLE
Add toolbar spacer to FilesView for iOS 26.0+

### DIFF
--- a/Melodee/Views/Files/FilesView.swift
+++ b/Melodee/Views/Files/FilesView.swift
@@ -71,6 +71,9 @@ struct FilesView: View {
                             Text("Library.SelectAnotherFolder")
                         }
                     }
+                    if #available(iOS 26.0, *) {
+                        ToolbarSpacer(.fixed)
+                    }
                 }
             }
             .sheet(isPresented: $isSelectingExternalDirectory) {

--- a/Melodee/Views/Files/FilesView.swift
+++ b/Melodee/Views/Files/FilesView.swift
@@ -64,7 +64,7 @@ struct FilesView: View {
             )
             .toolbar {
                 if hasSelectedExternalDirectory {
-                    ToolbarItem(placement: .topBarTrailing) {
+                    ToolbarItemGroup(placement: .topBarTrailing) {
                         Button {
                             isSelectingExternalDirectory = true
                         } label: {


### PR DESCRIPTION
## Summary
Added a conditional toolbar spacer to the FilesView to improve layout spacing on iOS 26.0 and later.

## Key Changes
- Added a `ToolbarSpacer(.fixed)` to the toolbar in FilesView, conditionally available for iOS 26.0+
- This provides better visual spacing in the toolbar area on supported iOS versions

## Implementation Details
- Used `#available(iOS 26.0, *)` availability check to ensure backward compatibility with earlier iOS versions
- The spacer is placed after the folder selection button in the toolbar

https://claude.ai/code/session_01NrdRfQQSTXmj47W5HndHsK