### PR TITLE
Add album art removal and improve tag editor functionality

### DIFF
--- a/Melodee/Localizable.xcstrings
+++ b/Melodee/Localizable.xcstrings
@@ -5478,6 +5478,46 @@
         }
       }
     },
+    "TagEditor.RemoveAlbumArt" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remove Album Art"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アルバムカバーを削除"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "앨범 아트 제거"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Xoá ảnh bìa album"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移除专辑封面"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移除專輯封面"
+          }
+        }
+      }
+    },
     "TagEditor.TagData" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Melodee/Structs/Tag.swift
+++ b/Melodee/Structs/Tag.swift
@@ -10,6 +10,7 @@ import Foundation
 struct Tag {
 
     var albumArt: Data?
+    var shouldRemoveAlbumArt: Bool = false
     var title: String?
     var artist: String?
     var album: String?

--- a/Melodee/Utilities/AudioFile.swift
+++ b/Melodee/Utilities/AudioFile.swift
@@ -82,9 +82,13 @@ extension AudioFile {
                 self.composer = replaceTokens(value, file: file)
             }
             // Build disc number
-            if let value = tagData.discNumber, let disc = Int(value) {
+            if let value = tagData.discNumber {
                 var currentDisc = self.discNumber
-                currentDisc.index = disc
+                if value.isEmpty {
+                    currentDisc.index = 0
+                } else if let disc = Int(value) {
+                    currentDisc.index = disc
+                }
                 self.discNumber = currentDisc
             }
             // Build album art - use setCoverArt method
@@ -94,6 +98,8 @@ extension AudioFile {
                 try data.write(to: tempURL)
                 try self.setCoverArt(imageLocation: tempURL)
                 try? FileManager.default.removeItem(at: tempURL)
+            } else if tagData.shouldRemoveAlbumArt {
+                try self.removeCoverArt()
             }
 
             let outputURL = URL(fileURLWithPath: file.path)

--- a/Melodee/Views/Tag Editor/TETagDataSection.swift
+++ b/Melodee/Views/Tag Editor/TETagDataSection.swift
@@ -73,7 +73,7 @@ struct TETagDataSection: View {
         }
         .onReceive(Just(tagData.genre)) { _ in
             if let genre = tagData.genre {
-                tagData.genre = genre.filter({ $0.isLetter || $0.isWhitespace })
+                tagData.genre = genre.filter({ $0.isLetter || $0.isWhitespace || $0 == "-" })
             }
         }
         .onReceive(Just(tagData.discNumber)) { _ in

--- a/Melodee/Views/Tag Editor/TagEditorView.swift
+++ b/Melodee/Views/Tag Editor/TagEditorView.swift
@@ -80,6 +80,15 @@ struct TagEditorView: View {
                             } label: {
                                 Text("TagEditor.SelectAlbumArt.FromFiles")
                             }
+                            if tagData.albumArt != nil {
+                                Button(role: .destructive) {
+                                    selectedPhoto = nil
+                                    tagData.albumArt = nil
+                                    tagData.shouldRemoveAlbumArt = true
+                                } label: {
+                                    Text("TagEditor.RemoveAlbumArt")
+                                }
+                            }
                         }
                     }
                     Spacer(minLength: .zero)
@@ -143,6 +152,7 @@ struct TagEditorView: View {
                     selectedPhoto = nil
                     let imageFileData: Data? = try? Data(contentsOf: url)
                     tagData.albumArt = imageFileData
+                    tagData.shouldRemoveAlbumArt = false
                 }
                 url.stopAccessingSecurityScopedResource()
             })
@@ -173,6 +183,7 @@ struct TagEditorView: View {
                 if let selectedPhoto = selectedPhoto,
                     let data = try? await selectedPhoto.loadTransferable(type: Data.self) {
                     tagData.albumArt = data
+                    tagData.shouldRemoveAlbumArt = false
                 }
             }
         }


### PR DESCRIPTION
## Summary
This PR enhances the tag editor with the ability to remove album art from audio files and improves tag data handling for disc numbers and genres.

## Key Changes
- **Album Art Removal**: Added a destructive "Remove Album Art" button that appears when album art is present, with full localization support (English, Japanese, Korean, Vietnamese, Simplified Chinese, Traditional Chinese)
- **Disc Number Handling**: Improved disc number parsing to handle empty values gracefully by setting the index to 0 instead of crashing
- **Genre Filtering**: Extended genre field validation to allow hyphens in addition to letters and whitespace
- **Tag Data Structure**: Added `shouldRemoveAlbumArt` flag to the `Tag` struct to track when album art should be removed from files
- **State Management**: Ensured the `shouldRemoveAlbumArt` flag is properly reset to `false` when new album art is selected

## Implementation Details
- The remove album art button only displays when `tagData.albumArt != nil`, preventing unnecessary UI clutter
- The `AudioFile.swift` extension now checks the `shouldRemoveAlbumArt` flag and calls `removeCoverArt()` when appropriate
- Album art selection (both from files and photo picker) now explicitly sets `shouldRemoveAlbumArt = false` to ensure proper state
- Disc number validation now handles empty strings as a valid input representing disc 0

https://claude.ai/code/session_019K61KnrioqL1xJDJwmMPxk