### PR TITLE
Fix MPNowPlayingInfo crash from @MainActor artwork handler

### DIFF
--- a/Melodee/Classes/MediaPlayerManager.swift
+++ b/Melodee/Classes/MediaPlayerManager.swift
@@ -280,15 +280,21 @@ class MediaPlayerManager: NSObject, AudioPlayer.Delegate {
         var nowPlayingInfo = [String: Any]()
         nowPlayingInfo[MPMediaItemPropertyTitle] = currentlyPlayingTitle() ?? ""
         nowPlayingInfo[MPMediaItemPropertyArtist] = "Melodee"
-        nowPlayingInfo[MPMediaItemPropertyArtwork] = MPMediaItemArtwork(boundsSize: albumArt.size) { _ in
-            return albumArt
-        }
+        // The artwork request handler is invoked by MPNowPlayingInfoCenter on its own
+        // serial access queue. Build it from a nonisolated context so the closure is not
+        // inferred as @MainActor — otherwise Swift's isolation check crashes the process
+        // (dispatch_assert_queue) when jpegDataWithSize: calls back off the main actor.
+        nowPlayingInfo[MPMediaItemPropertyArtwork] = Self.makeArtwork(from: albumArt)
         if let time = audioPlayer.time {
             nowPlayingInfo[MPNowPlayingInfoPropertyElapsedPlaybackTime] = time.currentTime
             nowPlayingInfo[MPMediaItemPropertyPlaybackDuration] = time.totalTime
         }
         nowPlayingInfo[MPNowPlayingInfoPropertyPlaybackRate] = playing ? 1.0 : 0.0
         nowPlayingInfoCenter.nowPlayingInfo = nowPlayingInfo
+    }
+
+    private static func makeArtwork(from image: UIImage) -> MPMediaItemArtwork {
+        MPMediaItemArtwork(boundsSize: image.size) { _ in image }
     }
 
     func albumArt() -> UIImage {


### PR DESCRIPTION
## Summary

Fixes the `dispatch_assert_queue` crash on `com.apple.MediaPlayer.MPNowPlayingInfoCenter/accessQueue` visible in the reported stack trace (`_swift_task_checkIsolatedSwift` → closure in `setNowPlayingOnMain()` → `-[MPMediaItemArtwork jpegDataWithSize:]`).

## Root cause

`MPMediaItemArtwork`'s request handler was being constructed inside `setNowPlayingOnMain()`, which is `@MainActor`-isolated. In Swift 6 the closure therefore inherits `@MainActor` isolation. When `MPNowPlayingInfoCenter` later invokes the handler on its internal serial access queue to build the remote-control artwork (via `jpegDataWithSize:`), Swift's isolation check fails a dispatch queue assertion and the process is killed.

## Fix

Move the `MPMediaItemArtwork` construction into a nonisolated `static` helper (`makeArtwork(from:)`) so the request-handler closure is not inferred as `@MainActor`. MPNowPlayingInfoCenter can then invoke it on its own queue safely. The `UIImage` is captured by the nonisolated closure (fine under `@preconcurrency import MediaPlayer`).

## Test plan

- [ ] Start playback of a track with embedded artwork; confirm now-playing info populates on the Lock Screen / Control Center without crashing.
- [ ] Start playback of a track without embedded artwork (falls back to `Album.Generic`).
- [ ] Skip forward/back through a queue repeatedly — previously this reliably reproduced the crash on the MP access queue.
- [ ] Verify Control Center remote commands (play/pause/seek/next/prev) still work.

https://claude.ai/code/session_01DCooAJbYLNNh1mosWptTa6

---
_Generated by [Claude Code](https://claude.ai/code/session_01DCooAJbYLNNh1mosWptTa6)_