### PR TITLE
Add folder creation via plus menu in file browser

### DIFF
--- a/Melodee/Localizable.xcstrings
+++ b/Melodee/Localizable.xcstrings
@@ -128,6 +128,47 @@
         }
       }
     },
+    "Alert.CreateFolder.Title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "New Folder"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新しいフォルダー"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "새 폴더"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Thư mục mới"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新建文件夹"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增資料夾"
+          }
+        }
+      }
+    },
     "Alert.DeleteFile.Text" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -3187,6 +3228,47 @@
         }
       }
     },
+    "Shared.Folder" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Folder"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "フォルダー"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "폴더"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Thư mục"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文件夹"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "資料夾"
+          }
+        }
+      }
+    },
     "Shared.iCloudDrive" : {
       "localizations" : {
         "en" : {
@@ -3867,6 +3949,47 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "播放"
+          }
+        }
+      }
+    },
+    "Shared.Playlist" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Playlist"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "再生リスト"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "재생목록"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Danh sách phát"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "播放列表"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "播放清單"
           }
         }
       }

--- a/Melodee/Views/Files/FolderView.swift
+++ b/Melodee/Views/Files/FolderView.swift
@@ -21,6 +21,8 @@ struct FolderView: View {
     @State var isSelectingExternalDirectory = false
     @State var storageLocation: StorageLocation = .local
     @State var isCreatingPlaylist = false
+    @State var isCreatingFolder = false
+    @State var newFolderName: String = ""
 
     var overrideStorageLocation: StorageLocation?
 
@@ -147,10 +149,20 @@ struct FolderView: View {
         )
         .toolbar {
             ToolbarItemGroup(placement: .topBarTrailing) {
-                Button {
-                    isCreatingPlaylist = true
+                Menu {
+                    Button {
+                        newFolderName = ""
+                        isCreatingFolder = true
+                    } label: {
+                        Label("Shared.Folder", systemImage: "folder")
+                    }
+                    Button {
+                        isCreatingPlaylist = true
+                    } label: {
+                        Label("Shared.Playlist", systemImage: "music.note.list")
+                    }
                 } label: {
-                    Image(systemName: "music.note.list")
+                    Image(systemName: "plus")
                 }
             }
             ToolbarSpacer(.fixed, placement: .topBarTrailing)
@@ -253,6 +265,25 @@ struct FolderView: View {
                 refreshFiles()
             }
         }
+        .alert("Alert.CreateFolder.Title", isPresented: $isCreatingFolder) {
+            TextField("Shared.NewDirectoryName", text: $newFolderName)
+            Button("Shared.Create") {
+                createFolder()
+            }
+            .disabled(newFolderName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            Button("Shared.Cancel", role: .cancel) {
+                newFolderName = ""
+            }
+        }
+    }
+
+    func createFolder() {
+        let trimmedName = newFolderName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedName.isEmpty else { return }
+        let folderURL = currentDirectoryURL().appendingPathComponent(trimmedName, isDirectory: true)
+        fileManager.createDirectory(at: folderURL.path(percentEncoded: false))
+        newFolderName = ""
+        refreshFiles()
     }
 
     func currentDirectoryURL() -> URL {

--- a/Melodee/Views/Playlists/CreatePlaylistSheet.swift
+++ b/Melodee/Views/Playlists/CreatePlaylistSheet.swift
@@ -146,16 +146,15 @@ struct CreatePlaylistSheet: View {
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
-                    Button("Shared.Cancel") {
+                    Button(role: .cancel) {
                         dismiss()
                     }
                 }
                 ToolbarItem(placement: .confirmationAction) {
-                    Button("Shared.Save") {
+                    Button(role: .confirm) {
                         createPlaylist()
                         dismiss()
                     }
-                    .bold()
                     .disabled(playlistName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
                               || selectedFiles.isEmpty)
                 }


### PR DESCRIPTION
## Summary
- Replace the standalone create-playlist toolbar button with a plus menu offering Folder and Playlist options
- Folder option presents a simple alert asking for a name, then creates the directory in the current folder
- Playlist option still opens the existing CreatePlaylistSheet, but its Cancel/Save toolbar buttons are now `Button(role: .cancel)` and `Button(role: .confirm)` without labels
- Add `Alert.CreateFolder.Title`, `Shared.Folder`, and `Shared.Playlist` localizations (en/ja/ko/vi/zh-Hans/zh-Hant)

## Test plan
- [ ] Tap the new plus button in a folder toolbar and verify the menu shows Folder and Playlist options
- [ ] Choose Folder, enter a name, and confirm the new directory appears after refresh
- [ ] Verify Create is disabled when the folder name is empty/whitespace
- [ ] Choose Playlist and confirm the sheet opens with role-only cancel/confirm buttons
- [ ] Verify localized strings render in all supported languages

https://claude.ai/code/session_01R7ERsqTPKkCWXD9rzXjQKP

---
_Generated by [Claude Code](https://claude.ai/code/session_01R7ERsqTPKkCWXD9rzXjQKP)_