### PR TITLE
Localize folder creation alert title and placeholder

### DIFF
--- a/Melodee/Localizable.xcstrings
+++ b/Melodee/Localizable.xcstrings
@@ -146,25 +146,25 @@
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "새 폴더"
+            "value" : "폴더 만들기"
           }
         },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Thư mục mới"
+            "value" : "Tạo thư mục"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "新建文件夹"
+            "value" : "创建文件夹"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "新增資料夾"
+            "value" : "建立資料夾"
           }
         }
       }
@@ -3368,25 +3368,25 @@
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "새 폴더 이름"
+            "value" : "폴더 이름"
           }
         },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tên thư mục mới"
+            "value" : "Tên thư mục"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "新文件夹名称"
+            "value" : "文件夹名称"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "新資料夾名稱"
+            "value" : "資料夾名稱"
           }
         }
       }

--- a/Melodee/Localizable.xcstrings
+++ b/Melodee/Localizable.xcstrings
@@ -134,13 +134,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "New Folder"
+            "value" : "Create Folder"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "新しいフォルダー"
+            "value" : "フォルダーを作成"
           }
         },
         "ko" : {
@@ -3356,13 +3356,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "New Folder Name"
+            "value" : "Folder Name"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "新しいフォルダー名"
+            "value" : "フォルダー名"
           }
         },
         "ko" : {


### PR DESCRIPTION
## Summary

- Update `Alert.CreateFolder.Title`: "New Folder" → "Create Folder" / "新しいフォルダー" → "フォルダーを作成"
- Update `Shared.NewDirectoryName` placeholder: "New Folder Name" → "Folder Name" / "新しいフォルダー名" → "フォルダー名"

## Test plan

- [ ] Open the Files tab and tap the create folder button
- [ ] Verify the alert title shows "Create Folder" (English) or "フォルダーを作成" (Japanese)
- [ ] Verify the text field placeholder shows "Folder Name" (English) or "フォルダー名" (Japanese)

https://claude.ai/code/session_01E16RVouAWV4NRfB1Squ4ms

---
_Generated by [Claude Code](https://claude.ai/code/session_01E16RVouAWV4NRfB1Squ4ms)_