### PR TITLE
Bump to 2.0.1 and ensure Licenses.plist is always created

### DIFF
--- a/Melodee.xcodeproj/project.pbxproj
+++ b/Melodee.xcodeproj/project.pbxproj
@@ -387,7 +387,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 2.0;
+				MARKETING_VERSION = 2.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tsubuzaki.Melodee;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
@@ -435,7 +435,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 2.0;
+				MARKETING_VERSION = 2.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tsubuzaki.Melodee;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;

--- a/Scripts/generate_licenses.sh
+++ b/Scripts/generate_licenses.sh
@@ -5,17 +5,22 @@ RESOLVED="${SRCROOT}/Melodee.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/
 CHECKOUTS="${BUILD_DIR%Build/*}SourcePackages/checkouts"
 OUTPUT="${SRCROOT}/Melodee/Licenses.plist"
 
+mkdir -p "$(dirname "$OUTPUT")"
+
+echo '{}' | plutil -convert xml1 -o "$OUTPUT" -
+plutil -insert dependencies -array "$OUTPUT"
+
 if [ ! -f "$RESOLVED" ]; then
-    echo "error: Package.resolved not found at $RESOLVED"
-    exit 1
+    echo "warning: Package.resolved not found at $RESOLVED"
+    echo "Generated $OUTPUT with 0 entries"
+    exit 0
 fi
 
 if [ ! -d "$CHECKOUTS" ]; then
-    echo "error: SourcePackages/checkouts not found at $CHECKOUTS"
-    exit 1
+    echo "warning: SourcePackages/checkouts not found at $CHECKOUTS"
+    echo "Generated $OUTPUT with 0 entries"
+    exit 0
 fi
-
-mkdir -p "$(dirname "$OUTPUT")"
 
 PIN_COUNT=$(plutil -extract pins raw -o - "$RESOLVED")
 
@@ -64,9 +69,6 @@ done
 
 SORTED_TSV=$(mktemp)
 sort -t $'\t' -k1,1 "$ENTRIES_TSV" > "$SORTED_TSV"
-
-echo '{}' | plutil -convert xml1 -o "$OUTPUT" -
-plutil -insert dependencies -array "$OUTPUT"
 
 INDEX=0
 COUNT=0


### PR DESCRIPTION
## Summary

- Bumped `MARKETING_VERSION` from `2.0` to `2.0.1`.
- Fixed `Scripts/generate_licenses.sh` so the dependencies `Licenses.plist` is always created during build, mirroring the same fragile pattern used in Tunetag's script.

## Why

The `Generate Licenses` build phase declares `Melodee/Licenses.plist` as its output path. Previously the plist was written only after the pin-processing loop completed, so under `set -euo pipefail` any earlier failure aborted the script before the file was created — most notably the hard `exit 1` paths when `Package.resolved` or `SourcePackages/checkouts` weren't yet populated (e.g., a clean checkout/CI build). The build then failed because the declared output was missing.

## Fix

- Create the empty plist with a `dependencies` array up-front, immediately after `mkdir -p`.
- Downgrade missing `Package.resolved` / missing `SourcePackages/checkouts` from `exit 1` errors to warnings followed by `exit 0`, so the empty plist is still emitted.
- Removed the now-redundant plist initialization that previously sat between the pin loop and the entry-writing loop.

## Test plan

- [ ] Clean build (delete DerivedData) → confirm `Melodee/Licenses.plist` is generated and bundled.
- [ ] Incremental build → confirm `Licenses.plist` still contains all dependency entries.
- [ ] Verify the More → Attributions screen lists dependencies as expected.

---
_Generated by [Claude Code](https://claude.ai/code/session_019TX23TQEpv7cvjhaQFPuWp)_