### PR TITLE
Add ci_scripts/ci_post_clone.sh for Xcode Cloud licenses

### DIFF
--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -euo pipefail
+
+# Xcode Cloud's user script sandbox can prevent the in-build "Generate
+# Licenses" phase from writing Melodee/Licenses.plist before the Resources
+# phase copies it. Run the same generator here so the file exists in the
+# source tree before xcodebuild starts.
+
+cd "$CI_PRIMARY_REPOSITORY_PATH"
+
+xcodebuild -resolvePackageDependencies \
+    -project Melodee.xcodeproj \
+    -scheme Melodee \
+    -derivedDataPath "$CI_DERIVED_DATA_PATH"
+
+# generate_licenses.sh derives the SourcePackages path from
+# ${BUILD_DIR%Build/*}SourcePackages/checkouts, so point BUILD_DIR at
+# $CI_DERIVED_DATA_PATH/Build/ to land on $CI_DERIVED_DATA_PATH/SourcePackages/checkouts.
+export SRCROOT="$CI_PRIMARY_REPOSITORY_PATH"
+export BUILD_DIR="$CI_DERIVED_DATA_PATH/Build/"
+
+"$CI_PRIMARY_REPOSITORY_PATH/Scripts/generate_licenses.sh"


### PR DESCRIPTION
## Summary
- Add `ci_scripts/ci_post_clone.sh` so Xcode Cloud generates `Melodee/Licenses.plist` before xcodebuild starts. The in-build "Generate Licenses" phase isn't reliable on Xcode Cloud (user script sandbox / timing relative to the Resources phase), which leaves the bundle without a populated `Licenses.plist`.
- The script resolves Swift Package dependencies into `$CI_DERIVED_DATA_PATH`, then runs the existing `Scripts/generate_licenses.sh` with `SRCROOT` and `BUILD_DIR` set so its `${BUILD_DIR%Build/*}SourcePackages/checkouts` path resolution lands on `$CI_DERIVED_DATA_PATH/SourcePackages/checkouts`.

## Test plan
- [ ] Trigger an Xcode Cloud build and confirm `ci_post_clone.sh` runs and prints "Generated …/Melodee/Licenses.plist with N entries" with N > 0.
- [ ] Open the resulting build's `MoreLicensesView` and verify dependency licenses are listed.
- [ ] Local Xcode build still produces a populated `Licenses.plist` via the existing build phase.

https://claude.ai/code/session_0198iuU5C5jnwsKmbBqtujbm

---
_Generated by [Claude Code](https://claude.ai/code/session_0198iuU5C5jnwsKmbBqtujbm)_