### PR TITLE
Ignore undownloaded iCloud files when sorting

### DIFF
--- a/Melodee/Views/Files/FolderView.swift
+++ b/Melodee/Views/Files/FolderView.swift
@@ -408,10 +408,11 @@ struct FolderView: View {
         }
 
         // Build tag cache for tag-based sort options
+        // Skip evicted iCloud files to avoid triggering downloads that would freeze the UI
         var tagCache: [String: AudioFile] = [:]
         if state.sortOption != .fileName {
             for item in audioFiles {
-                if let file = item as? FSFile, file.isTaggableAudio(),
+                if let file = item as? FSFile, file.isTaggableAudio(), !file.isEvicted(),
                    let audioFile = AudioFile.read(for: file) {
                     tagCache[file.path] = audioFile
                 }


### PR DESCRIPTION
## Summary
- When `FolderView.sortFiles()` builds its tag cache for tag-based sort options (track title/number, album, artist), it called `AudioFile.read(for:)` for every audio file in the folder. For evicted iCloud files this forces a synchronous download, freezing the UI.
- Skip evicted files (`file.isEvicted()`) when building the tag cache, matching the existing defensive pattern already used in `FBAudioFileRow` and `ListFileRow`. Evicted files still appear in the list and sort by their fallback values (empty string / `Int.max`).

## Test plan
- [ ] Open a folder containing a mix of downloaded and undownloaded iCloud audio files
- [ ] Switch sort option to Track Title / Track Number / Album / Artist and confirm the UI does not hang
- [ ] Verify undownloaded files appear in the list and aren't pulled down by the sort itself
- [ ] Confirm tag-based sorting still works for downloaded files

https://claude.ai/code/session_01DK1FHvmt6XfT7YTARyxTs5

---
_Generated by [Claude Code](https://claude.ai/code/session_01DK1FHvmt6XfT7YTARyxTs5)_