### PR TITLE
Refresh album art after iCloud downloads complete

### DIFF
--- a/Melodee/Classes/MediaPlayerManager.swift
+++ b/Melodee/Classes/MediaPlayerManager.swift
@@ -26,6 +26,7 @@ class MediaPlayerManager: NSObject, AudioPlayer.Delegate {
     var repeatMode: RepeatMode = .none
     var queue: [FSFile] = []
     var currentlyPlayingID: String = ""
+    var metadataRefreshTrigger: UUID = UUID()
 
     @ObservationIgnored private var cachedMetadataID: String = ""
     @ObservationIgnored private var cachedTitle: String?
@@ -97,7 +98,6 @@ class MediaPlayerManager: NSObject, AudioPlayer.Delegate {
 
     private func refreshMetadataCacheIfNeeded(for file: FSFile) {
         guard cachedMetadataID != currentlyPlayingID else { return }
-        cachedMetadataID = currentlyPlayingID
         cachedTitle = nil
         cachedArtist = nil
         cachedAlbum = nil
@@ -106,8 +106,10 @@ class MediaPlayerManager: NSObject, AudioPlayer.Delegate {
               FileManager.default.fileExists(atPath: file.path),
               !file.isEvicted(),
               let metadata = AudioFile.read(for: file)?.metadata else {
+            // Leave cachedMetadataID untouched so a later call can retry once the file is available.
             return
         }
+        cachedMetadataID = currentlyPlayingID
         cachedTitle = metadata.title
         cachedArtist = metadata.artist
         cachedAlbum = metadata.albumTitle
@@ -115,6 +117,11 @@ class MediaPlayerManager: NSObject, AudioPlayer.Delegate {
                         ?? metadata.attachedPictures.first)?.imageData {
             cachedAlbumArt = UIImage(data: data)
         }
+    }
+
+    private func invalidateMetadataCache() {
+        cachedMetadataID = ""
+        metadataRefreshTrigger = UUID()
     }
 
     func currentlyPlayingFile() -> FSFile? {
@@ -159,6 +166,7 @@ class MediaPlayerManager: NSObject, AudioPlayer.Delegate {
             isPlaybackActive = true
             isPaused = true
             downloadManager.startDownload(for: file) { [weak self] in
+                self?.invalidateMetadataCache()
                 self?.loadAndPlay(file)
             }
             return
@@ -224,6 +232,7 @@ class MediaPlayerManager: NSObject, AudioPlayer.Delegate {
             isPlaybackActive = true
             isPaused = true
             downloadManager.startDownload(for: file) { [weak self] in
+                self?.invalidateMetadataCache()
                 self?.loadAndPlay(file)
             }
         } else {

--- a/Melodee/Views/Now Playing/NowPlayingBar.swift
+++ b/Melodee/Views/Now Playing/NowPlayingBar.swift
@@ -76,6 +76,9 @@ struct NowPlayingBar: View {
             setAlbumArt()
             previousQueueID = mediaPlayer.currentlyPlayingID
         })
+        .onChange(of: mediaPlayer.metadataRefreshTrigger, { _, _ in
+            setAlbumArt()
+        })
     }
 
     func setAlbumArt() {

--- a/Melodee/Views/Now Playing/NowPlayingView.swift
+++ b/Melodee/Views/Now Playing/NowPlayingView.swift
@@ -89,6 +89,9 @@ struct NowPlayingView: View {
                 previousQueueID = mediaPlayer.currentlyPlayingID
             }
         })
+        .onChange(of: mediaPlayer.metadataRefreshTrigger, { _, _ in
+            setAlbumArt()
+        })
     }
 
     func setAlbumArt() {

--- a/Melodee/Views/Shared/ListFileRow.swift
+++ b/Melodee/Views/Shared/ListFileRow.swift
@@ -85,41 +85,51 @@ struct ListFileRow: View {
         }
         .task {
             if !isThumbnailFetchCompleted {
-                // Don't try to read thumbnails from evicted iCloud files
-                guard !file.isEvicted() else {
-                    isThumbnailFetchCompleted = true
-                    return
-                }
-                let filePath = file.path
-                let isTaggable = file.isTaggableAudio()
-                let isImage = file.type == .image
-                Task.detached {
-                    let fileURL: URL = URL(filePath: filePath)
-                    if isTaggable {
-                        NSFileCoordinator().coordinate(readingItemAt: fileURL, error: .none) { url in
-                            Task { @MainActor in
-                                let albumArt = await albumArt(at: url)
-                                withAnimation(.default.speed(2)) {
-                                    self.thumbnail = albumArt
-                                }
-                            }
+                fetchThumbnail()
+            }
+        }
+        .onChange(of: downloadManager.isDownloading(file)) { wasDownloading, isDownloading in
+            // When a download finishes, the thumbnail we tried (or skipped) earlier can now succeed.
+            if wasDownloading && !isDownloading {
+                fetchThumbnail()
+            }
+        }
+    }
+
+    private func fetchThumbnail() {
+        // Don't try to read thumbnails from evicted iCloud files
+        guard !file.isEvicted() else {
+            isThumbnailFetchCompleted = true
+            return
+        }
+        let filePath = file.path
+        let isTaggable = file.isTaggableAudio()
+        let isImage = file.type == .image
+        Task.detached {
+            let fileURL: URL = URL(filePath: filePath)
+            if isTaggable {
+                NSFileCoordinator().coordinate(readingItemAt: fileURL, error: .none) { url in
+                    Task { @MainActor in
+                        let albumArt = await albumArt(at: url)
+                        withAnimation(.default.speed(2)) {
+                            self.thumbnail = albumArt
                         }
-                    } else if isImage {
-                        NSFileCoordinator().coordinate(readingItemAt: fileURL, error: .none) { url in
-                            Task { @MainActor in
-                                if let thumbnail = await UIImage(contentsOfFile: url.path(percentEncoded: false))?
-                                    .byPreparingThumbnail(ofSize: CGSize(width: 100.0, height: 100.0)) {
-                                    withAnimation(.default.speed(2)) {
-                                        self.thumbnail = thumbnail
-                                    }
-                                }
+                    }
+                }
+            } else if isImage {
+                NSFileCoordinator().coordinate(readingItemAt: fileURL, error: .none) { url in
+                    Task { @MainActor in
+                        if let thumbnail = await UIImage(contentsOfFile: url.path(percentEncoded: false))?
+                            .byPreparingThumbnail(ofSize: CGSize(width: 100.0, height: 100.0)) {
+                            withAnimation(.default.speed(2)) {
+                                self.thumbnail = thumbnail
                             }
                         }
                     }
                 }
-                isThumbnailFetchCompleted = true
             }
         }
+        isThumbnailFetchCompleted = true
     }
 
     func albumArt(at url: URL) async -> UIImage {


### PR DESCRIPTION
## Summary
- When an evicted iCloud file finishes downloading, refresh its album art in the file rows and the now-playing UI instead of leaving the generic placeholder in place.
- `MediaPlayerManager.refreshMetadataCacheIfNeeded` no longer stamps `cachedMetadataID` until the metadata read actually succeeds, so a later call once the file is on disk can populate the cache. A new observable `metadataRefreshTrigger` is bumped from the download completion callbacks (in both `playImmediately` and `play()`), and `NowPlayingView`/`NowPlayingBar` observe it to redraw their album art.
- `ListFileRow` now factors the thumbnail fetch into a helper and re-runs it via `.onChange(of: downloadManager.isDownloading(file))` when a download transitions from in-flight to finished, so the row picks up the embedded artwork as soon as it's available.

## Test plan
- [ ] Open a folder containing an evicted iCloud audio file; tap to play it and confirm the album art in the now-playing bar and full now-playing view switches from the generic placeholder to the embedded artwork once the download finishes (without changing tracks).
- [ ] Confirm the lock-screen / control-center artwork updates after the same download completes.
- [ ] Trigger a download for an evicted audio file from a file row (e.g. by tapping it) and confirm the row's thumbnail switches from the generic placeholder to the embedded artwork after the download completes.
- [ ] Repeat for an evicted image file and confirm the row's thumbnail appears post-download.
- [ ] Sanity check: locally-stored files still show their thumbnails immediately on first appearance.

---
_Generated by [Claude Code](https://claude.ai/code/session_015PRabVbfPXWBxyKJb7fCzX)_