### PR TITLE
Move iCloud filesystem I/O off the main thread to prevent UI freezes

### DIFF
--- a/Melodee/Classes/FileDownloadManager.swift
+++ b/Melodee/Classes/FileDownloadManager.swift
@@ -13,6 +13,7 @@ class FileDownloadManager {
     @ObservationIgnored private var metadataQuery: NSMetadataQuery?
     @ObservationIgnored private var observer: Any?
     @ObservationIgnored private var pollTimer: Timer?
+    @ObservationIgnored private let ioQueue = DispatchQueue(label: "com.melodee.filedownload.io", qos: .utility)
 
     /// Map of file path → download progress (0.0 to 1.0), nil means no progress data yet
     var downloadProgress: [String: Double?] = [:]
@@ -29,17 +30,23 @@ class FileDownloadManager {
     }
 
     func startDownload(for file: FSFile, onComplete: (() -> Void)? = nil) {
-        let url = URL(filePath: file.path)
+        let path = file.path
         if let onComplete {
-            completionHandlers[file.path] = onComplete
+            completionHandlers[path] = onComplete
         }
-        downloadProgress[file.path] = .some(nil)
-        do {
-            try FileManager.default.startDownloadingUbiquitousItem(at: url)
-        } catch {
-            debugPrint("Failed to start downloading: \(error.localizedDescription)")
-            downloadProgress.removeValue(forKey: file.path)
-            completionHandlers.removeValue(forKey: file.path)
+        downloadProgress[path] = .some(nil)
+        // Request the (potentially blocking) iCloud download off the main thread.
+        nonisolated(unsafe) let managerRef = self
+        ioQueue.async {
+            do {
+                try FileManager.default.startDownloadingUbiquitousItem(at: URL(filePath: path))
+            } catch {
+                debugPrint("Failed to start downloading: \(error.localizedDescription)")
+                DispatchQueue.main.async {
+                    managerRef.downloadProgress.removeValue(forKey: path)
+                    managerRef.completionHandlers.removeValue(forKey: path)
+                }
+            }
         }
     }
 
@@ -88,22 +95,36 @@ class FileDownloadManager {
     }
 
     private func pollForCompletedDownloads() {
-        for path in Array(downloadProgress.keys) {
-            let fileURL = URL(filePath: path)
-            // Check if the real file now exists on disk (not the .icloud placeholder)
-            guard FileManager.default.fileExists(atPath: fileURL.path(percentEncoded: false)) else {
-                continue
-            }
-            // Verify it's actually downloaded via resource values if it's a ubiquitous item
-            do {
-                let values = try fileURL.resourceValues(forKeys: [.ubiquitousItemDownloadingStatusKey])
-                if let status = values.ubiquitousItemDownloadingStatus, status != .current {
+        let paths = Array(downloadProgress.keys)
+        guard !paths.isEmpty else { return }
+        // Perform the filesystem existence/status checks off the main thread so polling never
+        // stalls the UI while downloads are in progress.
+        nonisolated(unsafe) let managerRef = self
+        ioQueue.async {
+            var completedPaths: [String] = []
+            for path in paths {
+                let fileURL = URL(filePath: path)
+                // Check if the real file now exists on disk (not the .icloud placeholder)
+                guard FileManager.default.fileExists(atPath: fileURL.path(percentEncoded: false)) else {
                     continue
                 }
-            } catch {
-                // Not a ubiquitous item or error reading - if the file exists, treat as downloaded
+                // Verify it's actually downloaded via resource values if it's a ubiquitous item
+                do {
+                    let values = try fileURL.resourceValues(forKeys: [.ubiquitousItemDownloadingStatusKey])
+                    if let status = values.ubiquitousItemDownloadingStatus, status != .current {
+                        continue
+                    }
+                } catch {
+                    // Not a ubiquitous item or error reading - if the file exists, treat as downloaded
+                }
+                completedPaths.append(path)
             }
-            markCompleted(path: path)
+            guard !completedPaths.isEmpty else { return }
+            DispatchQueue.main.async {
+                for path in completedPaths {
+                    managerRef.markCompleted(path: path)
+                }
+            }
         }
     }
 

--- a/Melodee/Classes/FileDownloadManager.swift
+++ b/Melodee/Classes/FileDownloadManager.swift
@@ -35,7 +35,6 @@ class FileDownloadManager {
             completionHandlers[path] = onComplete
         }
         downloadProgress[path] = .some(nil)
-        // Request the (potentially blocking) iCloud download off the main thread.
         nonisolated(unsafe) let managerRef = self
         ioQueue.async {
             do {
@@ -97,8 +96,6 @@ class FileDownloadManager {
     private func pollForCompletedDownloads() {
         let paths = Array(downloadProgress.keys)
         guard !paths.isEmpty else { return }
-        // Perform the filesystem existence/status checks off the main thread so polling never
-        // stalls the UI while downloads are in progress.
         nonisolated(unsafe) let managerRef = self
         ioQueue.async {
             var completedPaths: [String] = []

--- a/Melodee/Classes/FilesystemManager.swift
+++ b/Melodee/Classes/FilesystemManager.swift
@@ -58,9 +58,6 @@ class FilesystemManager {
                         }
 
                         if url.hasDirectoryPath {
-                            // Only descend into subdirectories when a recursive listing is requested.
-                            // The file browser shows a single level, so recursing there reads the
-                            // entire iCloud subtree synchronously and freezes the UI for no benefit.
                             return FSDirectory(name: url.lastPathComponent,
                                                path: url.path,
                                                files: recursive ? files(in: url, recursive: true) : [])

--- a/Melodee/Classes/FilesystemManager.swift
+++ b/Melodee/Classes/FilesystemManager.swift
@@ -40,7 +40,7 @@ class FilesystemManager {
         }
     }
 
-    func files(in url: URL? = nil) -> [any FilesystemObject] {
+    func files(in url: URL? = nil, recursive: Bool = true) -> [any FilesystemObject] {
         debugPrint("Enumerating files in '\(url == nil ? directory?.absoluteString ?? "": url?.absoluteString ?? "")'.")
         do {
             if let directory = (url == nil ? directory : url), directoryOrFileExists(at: directory) {
@@ -58,9 +58,12 @@ class FilesystemManager {
                         }
 
                         if url.hasDirectoryPath {
+                            // Only descend into subdirectories when a recursive listing is requested.
+                            // The file browser shows a single level, so recursing there reads the
+                            // entire iCloud subtree synchronously and freezes the UI for no benefit.
                             return FSDirectory(name: url.lastPathComponent,
                                                path: url.path,
-                                               files: files(in: url))
+                                               files: recursive ? files(in: url, recursive: true) : [])
                         } else {
                             // Get actual path for dataless files
                             let fileURL: URL = fileURL(for: url)

--- a/Melodee/Structs/FSFile.swift
+++ b/Melodee/Structs/FSFile.swift
@@ -73,6 +73,12 @@ struct FSFile: FilesystemObject {
 
     /// Returns true if this file is stored in iCloud and not yet downloaded locally
     func isEvicted() -> Bool {
+        return FSFile.isEvicted(atPath: path)
+    }
+
+    /// Returns true if the file at `path` is stored in iCloud and not yet downloaded locally.
+    /// Performs blocking filesystem I/O, so prefer calling it off the main thread.
+    static func isEvicted(atPath path: String) -> Bool {
         let url = URL(filePath: path)
         // Check if the .icloud placeholder file exists
         let placeholderName = ".\(url.lastPathComponent).icloud"

--- a/Melodee/Structs/FSFile.swift
+++ b/Melodee/Structs/FSFile.swift
@@ -76,8 +76,6 @@ struct FSFile: FilesystemObject {
         return FSFile.isEvicted(atPath: path)
     }
 
-    /// Returns true if the file at `path` is stored in iCloud and not yet downloaded locally.
-    /// Performs blocking filesystem I/O, so prefer calling it off the main thread.
     static func isEvicted(atPath path: String) -> Bool {
         let url = URL(filePath: path)
         // Check if the .icloud placeholder file exists

--- a/Melodee/Views/Files/FBAudioFileRow.swift
+++ b/Melodee/Views/Files/FBAudioFileRow.swift
@@ -24,8 +24,13 @@ struct FBAudioFileRow: View {
                 .tint(.primary)
         }
         .task(id: sortOption) {
-            // Don't read tags from evicted iCloud files
-            guard !file.isEvicted() else { return }
+            // Don't read tags from evicted iCloud files. Check eviction off the main thread so
+            // listing and scrolling never block on iCloud filesystem I/O.
+            let path = file.path
+            let evicted = await Task.detached(priority: .utility) {
+                FSFile.isEvicted(atPath: path)
+            }.value
+            guard !evicted else { return }
             tagSubtitle = readTagSubtitle()
         }
         .swipeActions(edge: .leading, allowsFullSwipe: true) {

--- a/Melodee/Views/Files/FBAudioFileRow.swift
+++ b/Melodee/Views/Files/FBAudioFileRow.swift
@@ -24,8 +24,7 @@ struct FBAudioFileRow: View {
                 .tint(.primary)
         }
         .task(id: sortOption) {
-            // Don't read tags from evicted iCloud files. Check eviction off the main thread so
-            // listing and scrolling never block on iCloud filesystem I/O.
+            // Don't read tags from evicted iCloud files
             let path = file.path
             let evicted = await Task.detached(priority: .utility) {
                 FSFile.isEvicted(atPath: path)

--- a/Melodee/Views/Files/FolderView.swift
+++ b/Melodee/Views/Files/FolderView.swift
@@ -335,9 +335,9 @@ struct FolderView: View {
         updateFileManagerDirectory()
         withAnimation {
             if let path = currentDirectory?.path {
-                self.files = fileManager.files(in: URL(fileURLWithPath: path))
+                self.files = fileManager.files(in: URL(fileURLWithPath: path), recursive: false)
             } else {
-                self.files = fileManager.files()
+                self.files = fileManager.files(recursive: false)
             }
             sortFiles()
             state.isInitialLoadCompleted = true

--- a/Melodee/Views/Shared/ListFileRow.swift
+++ b/Melodee/Views/Shared/ListFileRow.swift
@@ -89,8 +89,7 @@ struct ListFileRow: View {
             await loadFileMetadata()
         }
         .onChange(of: downloadManager.isDownloading(file)) { wasDownloading, isDownloading in
-            // When a download finishes, the file is now local: refresh eviction state, size and
-            // the thumbnail we previously skipped.
+            // When a download finishes, refresh eviction state, size and thumbnail
             if wasDownloading && !isDownloading {
                 isThumbnailFetchCompleted = false
                 Task { await loadFileMetadata() }
@@ -98,9 +97,7 @@ struct ListFileRow: View {
         }
     }
 
-    /// Reads eviction status and file size off the main thread, then caches them in state, so the
-    /// row body never performs blocking iCloud filesystem I/O while rendering. Without this, every
-    /// download-progress update re-renders the row and freezes the UI during downloads.
+    /// Reads eviction status and file size off the main thread and caches them in state.
     private func loadFileMetadata() async {
         let path = file.path
         let wantSize = (subtitle == nil)

--- a/Melodee/Views/Shared/ListFileRow.swift
+++ b/Melodee/Views/Shared/ListFileRow.swift
@@ -17,6 +17,8 @@ struct ListFileRow: View {
     var subtitle: String?
     @State var thumbnail: UIImage?
     @State var isThumbnailFetchCompleted: Bool = false
+    @State var isEvicted: Bool = false
+    @State var fileSizeText: String = ""
 
     var body: some View {
         HStack(alignment: .center, spacing: 16.0) {
@@ -52,7 +54,7 @@ struct ListFileRow: View {
                     .font(.body)
                     .lineLimit(1)
                     .truncationMode(.middle)
-                Text(subtitle ?? URL(filePath: file.path).fileSizeString)
+                Text(subtitle ?? fileSizeText)
                     .font(.caption)
                     .lineLimit(1)
                     .truncationMode(.middle)
@@ -67,7 +69,7 @@ struct ListFileRow: View {
                     ProgressView()
                         .controlSize(.small)
                 }
-            } else if file.isEvicted() {
+            } else if isEvicted {
                 Image(systemName: "icloud.and.arrow.down")
                     .font(.body)
                     .foregroundStyle(.secondary)
@@ -83,25 +85,38 @@ struct ListFileRow: View {
                     .clipShape(RoundedRectangle(cornerRadius: 4.0))
             }
         }
-        .task {
-            if !isThumbnailFetchCompleted {
-                fetchThumbnail()
-            }
+        .task(id: file.path) {
+            await loadFileMetadata()
         }
         .onChange(of: downloadManager.isDownloading(file)) { wasDownloading, isDownloading in
-            // When a download finishes, the thumbnail we tried (or skipped) earlier can now succeed.
+            // When a download finishes, the file is now local: refresh eviction state, size and
+            // the thumbnail we previously skipped.
             if wasDownloading && !isDownloading {
-                fetchThumbnail()
+                isThumbnailFetchCompleted = false
+                Task { await loadFileMetadata() }
             }
         }
     }
 
-    private func fetchThumbnail() {
-        // Don't try to read thumbnails from evicted iCloud files
-        guard !file.isEvicted() else {
-            isThumbnailFetchCompleted = true
-            return
+    /// Reads eviction status and file size off the main thread, then caches them in state, so the
+    /// row body never performs blocking iCloud filesystem I/O while rendering. Without this, every
+    /// download-progress update re-renders the row and freezes the UI during downloads.
+    private func loadFileMetadata() async {
+        let path = file.path
+        let wantSize = (subtitle == nil)
+        let result = await Task.detached(priority: .utility) { () -> (evicted: Bool, sizeText: String) in
+            let evicted = FSFile.isEvicted(atPath: path)
+            let sizeText = wantSize ? URL(filePath: path).fileSizeString : ""
+            return (evicted, sizeText)
+        }.value
+        isEvicted = result.evicted
+        fileSizeText = result.sizeText
+        if !result.evicted && !isThumbnailFetchCompleted {
+            fetchThumbnail()
         }
+    }
+
+    private func fetchThumbnail() {
         let filePath = file.path
         let isTaggable = file.isTaggableAudio()
         let isImage = file.type == .image


### PR DESCRIPTION
## Summary

The main UI froze while iCloud files were downloading. Two causes:

1. **Per-render disk I/O during downloads.** While a download is in progress, `FileDownloadManager.downloadProgress` updates frequently (NSMetadataQuery + 0.5s poll). Every `ListFileRow` observes that dictionary, so each progress tick re-renders all visible rows — and each row's `body` performed **blocking iCloud I/O**: `file.isEvicted()` (`fileExists` + `resourceValues`) and `URL(...).fileSizeString` (`attributesOfItem`). Visible rows × progress ticks = a main-thread I/O storm that froze scrolling.
2. **Recursive synchronous enumeration.** `FilesystemManager.files(in:)` recursed into the *entire* directory subtree synchronously, but the file browser only displays a single level (the nested data is discarded; only the playlist sheets consume it). Opening an iCloud folder read the whole subtree on the main thread.

## Changes

- **`ListFileRow`**: computes eviction status and file size **off the main thread** and caches them in `@State`. The row `body` no longer performs any disk I/O, so download-progress re-renders are cheap. State is refreshed when a download completes.
- **`FileDownloadManager`**: `startDownloadingUbiquitousItem` and the completion-detection poll (`fileExists`/`resourceValues`) now run on a background queue; the observable `downloadProgress` and completion handlers are only touched on the main thread.
- **`FilesystemManager.files(in:)`**: gains a `recursive` flag (defaults to `true`, preserving existing callers). `FolderView` now lists a single level (`recursive: false`) instead of reading the whole subtree.
- **`FSFile`**: adds a static `isEvicted(atPath:)` helper so eviction can be checked from a background context using only a path `String`.
- **`FBAudioFileRow`**: checks eviction off the main thread before reading tags.

All concurrency follows the patterns already used in this codebase (`nonisolated(unsafe)` captures, `Task.detached` capturing only `Sendable` locals, MainActor View isolation). The `recursive: true` default keeps `FBContextMenu` and the playlist sheets behaving exactly as before.

## Test plan

- [ ] Build in Xcode (could not compile in the Linux dev environment — no toolchain).
- [ ] Browse an iCloud folder with many evicted files: listing/scrolling stays smooth.
- [ ] Tap an evicted track to play: download starts without freezing the UI; progress indicator updates; playback begins on completion.
- [ ] Confirm the cloud-download icon and file-size subtitle still appear (shortly after the row renders).
- [ ] Confirm download completion still refreshes album-art thumbnails.
- [ ] Confirm playlist creation/management (which relies on recursive enumeration) still lists nested audio files.

https://claude.ai/code/session_01RcMCB487esq73M2idwUknL

---
_Generated by [Claude Code](https://claude.ai/code/session_01RcMCB487esq73M2idwUknL)_